### PR TITLE
Allow integrating of buildings that are not the most expensive

### DIFF
--- a/building.js
+++ b/building.js
@@ -211,7 +211,7 @@ Building = Ice.$extend('Building', {
         if(!self.next) {
             return self.integrates_to() > 0;
         }
-        return self.integrates_to() > 0 && self.next.integrates_to() === 0;
+        return self.integrates_to() > 0;
     }
 });
 


### PR DESCRIPTION
I've found that it is often advantageous to not upgrade the most expensive path at certain times and it would be nice to have a way to do that. I'm not sure if you made it this way because you wanted the game to behave like this, or if it was from a UI standpoint.

The case that I find it is beneficial in is when you can get just one or two of the top building, but many billions of the next building down.
